### PR TITLE
LEXIO-38149: Support for union statements

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/NarrativeScience/cookiecutter-python-lib",
-  "commit": "f31f5912ab949296517c6d65fc666b11926a5cf8",
+  "commit": "06d791b4e3ac2362c595a9bcf0617f84e546ec3c",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/crma_api_client/__init__.py
+++ b/crma_api_client/__init__.py
@@ -2,4 +2,4 @@
 
 from .client import CRMAAPIClient
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/crma_api_client/client.py
+++ b/crma_api_client/client.py
@@ -218,5 +218,4 @@ class CRMAAPIClient:
             json_data["timezone"] = timezone
 
         response = await self.request("/wave/query", "POST", json_data=json_data)
-        self.logger.info("CRMA response", response=response.json())
         return QueryResponse.parse_obj(response.json())

--- a/crma_api_client/client.py
+++ b/crma_api_client/client.py
@@ -218,5 +218,5 @@ class CRMAAPIClient:
             json_data["timezone"] = timezone
 
         response = await self.request("/wave/query", "POST", json_data=json_data)
-
+        self.logger.info("CRMA response", response=response.json())
         return QueryResponse.parse_obj(response.json())

--- a/crma_api_client/client.py
+++ b/crma_api_client/client.py
@@ -218,4 +218,5 @@ class CRMAAPIClient:
             json_data["timezone"] = timezone
 
         response = await self.request("/wave/query", "POST", json_data=json_data)
+
         return QueryResponse.parse_obj(response.json())

--- a/crma_api_client/resources/query.py
+++ b/crma_api_client/resources/query.py
@@ -3,7 +3,7 @@
 
 from enum import Enum
 from functools import cached_property
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal, Union
 
 from pydantic import BaseModel
 
@@ -40,17 +40,24 @@ class LineageProjection(BaseModel):
     field: ProjectionField
 
 
-class QueryLineage(BaseModel):
+class ForeachLineage(BaseModel):
     """Lineage that describes field projections in a query result"""
 
-    type: str
+    type: Literal["foreach"] = "foreach"
     projections: List[LineageProjection]
+
+
+class UnionLineage(BaseModel):
+    """Lineage that describes the union of field projections in a query result"""
+
+    type: Literal["union"] = "union"
+    inputs: List[ForeachLineage]
 
 
 class QueryResultsMetadata(BaseModel):
     """Query results metadata"""
 
-    lineage: QueryLineage
+    lineage: Union[UnionLineage, ForeachLineage]
     query_language: QueryLanguage
 
     class Config:
@@ -84,7 +91,16 @@ class QueryResponse(BaseModel):
 
         This assumes there is only one metadata object and one lineage object.
         """
-        return [p.field for p in self.results.metadata[0].lineage.projections]
+        lineage = self.results.metadata[0].lineage
+        if isinstance(lineage, UnionLineage):
+            # Unions require that all inputs have the same structure, so we only
+            # need the projections from the first input
+           projections = lineage.inputs[0].projections
+        else:
+            projections = lineage.projections
+
+        return [p.field for p in projections]
+
 
     class Config:
         """Model configuration"""

--- a/crma_api_client/resources/query.py
+++ b/crma_api_client/resources/query.py
@@ -95,12 +95,11 @@ class QueryResponse(BaseModel):
         if isinstance(lineage, UnionLineage):
             # Unions require that all inputs have the same structure, so we only
             # need the projections from the first input
-           projections = lineage.inputs[0].projections
+            projections = lineage.inputs[0].projections
         else:
             projections = lineage.projections
 
         return [p.field for p in projections]
-
 
     class Config:
         """Model configuration"""

--- a/crma_api_client/resources/query.py
+++ b/crma_api_client/resources/query.py
@@ -56,13 +56,15 @@ class UnionLineage(BaseModel):
 
 
 # Define a submodel for lineage values
-Lineage = Annotated[Union[UnionLineage, ForeachLineage], Field(discriminator="type")]
+QueryLineage = Annotated[
+    Union[UnionLineage, ForeachLineage], Field(discriminator="type")
+]
 
 
 class QueryResultsMetadata(BaseModel):
     """Query results metadata"""
 
-    lineage: Lineage
+    lineage: QueryLineage
     query_language: QueryLanguage
 
     class Config:

--- a/crma_api_client/resources/query.py
+++ b/crma_api_client/resources/query.py
@@ -5,7 +5,8 @@ from enum import Enum
 from functools import cached_property
 from typing import Any, Dict, List, Literal, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 from .util import to_camel
 
@@ -54,10 +55,14 @@ class UnionLineage(BaseModel):
     inputs: List[ForeachLineage]
 
 
+# Define a submodel for lineage values
+Lineage = Annotated[Union[UnionLineage, ForeachLineage], Field(discriminator="type")]
+
+
 class QueryResultsMetadata(BaseModel):
     """Query results metadata"""
 
-    lineage: Union[UnionLineage, ForeachLineage]
+    lineage: Lineage
     query_language: QueryLanguage
 
     class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "crma-api-client"
-version = "0.6.0"
+version = "0.7.0"
 description = "CRM Analytics REST API Client"
 authors = ["Jonathan Drake <jon.drake@salesforce.com>"]
 license = "BSD-3-Clause"

--- a/tests/unit/test_resources/test_query.py
+++ b/tests/unit/test_resources/test_query.py
@@ -1,0 +1,148 @@
+"""Contains unit tests for the resources/query module"""
+
+from crma_api_client.resources.query import ProjectionField, QueryResponse
+
+
+def test_query_response_fields__foreach():
+    """Should return a list of projected fields from the foreach lineage"""
+    query_response = QueryResponse.parse_obj(
+        {
+            "action": "query",
+            "responseId": "response-id",
+            "query": "query-string",
+            "responseTime": 10,
+            "results": {
+                "records": [{}],
+                "metadata": [
+                    {
+                        "queryLanguage": "SAQL",
+                        "lineage": {
+                            "type": "foreach",
+                            "projections": [
+                                {
+                                    "field": {
+                                        "id": "q2.absolute_change",
+                                        "type": "numeric",
+                                    },
+                                    "inputs": [{"id": "q2.absolute_change"}],
+                                },
+                                {
+                                    "field": {
+                                        "id": "q2.relative_change",
+                                        "type": "numeric",
+                                    },
+                                    "inputs": [{"id": "q2.relative_change"}],
+                                },
+                                {
+                                    "field": {"id": "q2.entity", "type": "string"},
+                                    "inputs": [{"id": "q2.Category"}],
+                                },
+                                {"field": {"id": "q2.dimension", "type": "string"}},
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    assert query_response.fields == [
+        ProjectionField(id="q2.absolute_change", type="numeric"),
+        ProjectionField(id="q2.relative_change", type="numeric"),
+        ProjectionField(id="q2.entity", type="string"),
+        ProjectionField(id="q2.dimension", type="string"),
+    ]
+
+
+def test_query_response_fields__union():
+    """Should return a list of projected fields from the union lineage"""
+    query_response = QueryResponse.parse_obj(
+        {
+            "action": "query",
+            "responseId": "response-id",
+            "query": "query-string",
+            "responseTime": 10,
+            "results": {
+                "records": [{}],
+                "metadata": [
+                    {
+                        "queryLanguage": "SAQL",
+                        "lineage": {
+                            "type": "union",
+                            "inputs": [
+                                {
+                                    "type": "foreach",
+                                    "projections": [
+                                        {
+                                            "field": {
+                                                "id": "q2.absolute_change",
+                                                "type": "numeric",
+                                            },
+                                            "inputs": [{"id": "q2.absolute_change"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q2.relative_change",
+                                                "type": "numeric",
+                                            },
+                                            "inputs": [{"id": "q2.relative_change"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q2.entity",
+                                                "type": "string",
+                                            },
+                                            "inputs": [{"id": "q2.Category"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q2.dimension",
+                                                "type": "string",
+                                            }
+                                        },
+                                    ],
+                                },
+                                {
+                                    "type": "foreach",
+                                    "projections": [
+                                        {
+                                            "field": {
+                                                "id": "q5.absolute_change",
+                                                "type": "numeric",
+                                            },
+                                            "inputs": [{"id": "q5.absolute_change"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q5.relative_change",
+                                                "type": "numeric",
+                                            },
+                                            "inputs": [{"id": "q5.relative_change"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q5.entity",
+                                                "type": "string",
+                                            },
+                                            "inputs": [{"id": "q5.State"}],
+                                        },
+                                        {
+                                            "field": {
+                                                "id": "q5.dimension",
+                                                "type": "string",
+                                            }
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    assert query_response.fields == [
+        ProjectionField(id="q2.absolute_change", type="numeric"),
+        ProjectionField(id="q2.relative_change", type="numeric"),
+        ProjectionField(id="q2.entity", type="string"),
+        ProjectionField(id="q2.dimension", type="string"),
+    ]


### PR DESCRIPTION
# Overview of changes
A SAQL query that unions multiple streams together will return a "union" lineage rather than a "foreach" lineage. Union lineages have different parameters, so I added new `UnionLineage` and `ForeachLineage` types. I also updated the `QueryResultsMetadata` and `QueryResponse` types to reflect this.

## For software test
not sure?
